### PR TITLE
Fix case for imports and packages

### DIFF
--- a/code/test/Model/Habit/TestConstructor.java
+++ b/code/test/Model/Habit/TestConstructor.java
@@ -1,4 +1,4 @@
-package code.test.model.habit;
+package code.test.Model.Habit;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/code/test/Model/Habit/TestSetters.java
+++ b/code/test/Model/Habit/TestSetters.java
@@ -1,4 +1,4 @@
-package code.test.model.habit;
+package code.test.Model.Habit;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/code/test/ViewModel/TestAddHabit.java
+++ b/code/test/ViewModel/TestAddHabit.java
@@ -1,11 +1,11 @@
-package code.test.viewmodel;
+package code.test.ViewModel;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
 import code.model.Frequency;
-import code.viewmodel.HabitViewModel;
+import code.viewModel.HabitViewModel;
 
 class TestAddHabit {
 	@Test
@@ -26,11 +26,11 @@ class TestAddHabit {
 		viewModel.habitNameProperty().set(null);
 		viewModel.frequencyProperty().set(Frequency.MONTHLY);
 		assertThrows(
-						IllegalArgumentException.class, 
-						()->{
-							viewModel.addHabit();
-						}
-					);
+			IllegalArgumentException.class, 
+			()->{
+				viewModel.addHabit();
+			}
+		);
 	}
 
 	@Test
@@ -39,10 +39,10 @@ class TestAddHabit {
 		viewModel.habitNameProperty().set("");
 		viewModel.frequencyProperty().set(Frequency.MONTHLY);
 		assertThrows(
-						IllegalArgumentException.class, 
-						()->{
-							viewModel.addHabit();
-						}
-					);
+			IllegalArgumentException.class, 
+			()->{
+				viewModel.addHabit();
+			}
+		);
 	}
 }

--- a/code/test/ViewModel/TestSetHabitCompletion.java
+++ b/code/test/ViewModel/TestSetHabitCompletion.java
@@ -1,11 +1,11 @@
-package code.test.viewmodel;
+package code.test.ViewModel;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
 import code.model.Habit;
-import code.viewmodel.HabitViewModel;
+import code.viewModel.HabitViewModel;
 import code.model.Frequency;
 
 class TestSetHabitCompletion {

--- a/code/view/LoginScreen.java
+++ b/code/view/LoginScreen.java
@@ -1,4 +1,4 @@
-package code.view
+package code.view;
 
 import java.net.URL;
 import java.util.ResourceBundle;
@@ -6,7 +6,6 @@ import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.TextField;
-import javafx.scene.image.ImageView;
 
 public class LoginScreen {
 

--- a/code/viewModel/HabitViewModel.java
+++ b/code/viewModel/HabitViewModel.java
@@ -1,4 +1,4 @@
-package code.viewmodel;
+package code.viewModel;
 
 import code.model.Habit;
 


### PR DESCRIPTION
The folder names were updated in a previous commit, but github didn't track the change in casing. The casing for the code has been reverted for the time being.