### PR TITLE
Login and Registration feedback

### DIFF
--- a/code/src/main/java/habit_mode/view/codebehind/LoginScreen.java
+++ b/code/src/main/java/habit_mode/view/codebehind/LoginScreen.java
@@ -8,9 +8,11 @@ import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
+import javafx.scene.control.Alert.AlertType;
 import javafx.stage.Stage;
 import javafx.scene.Node;
 import habit_mode.model.SuccessCode;
@@ -69,7 +71,7 @@ public class LoginScreen {
 
                 app_stage.show();
             } else {
-                System.out.print("Login failed.");
+                this.presentErrorDialog(this.viewModel.validateLogin());
             } 
         } catch (Exception error) {
             System.out.print(error.getLocalizedMessage());
@@ -89,7 +91,7 @@ public class LoginScreen {
             if (this.viewModel.registerUser() == SuccessCode.OKAY) {
                 this.loginButtonPress(event);
             } else {
-                System.out.print("Registration failed.");
+                this.presentErrorDialog(this.viewModel.registerUser());
             }
         } catch (Exception error) {
             System.out.print(error.getLocalizedMessage());
@@ -109,6 +111,37 @@ public class LoginScreen {
         assert this.passwordTextField != null : "fx:id=\"passwordTextField\" was not injected: check your FXML file 'LoginScreen.fxml'.";
         assert this.userNameTextField != null : "fx:id=\"userNameTextField\" was not injected: check your FXML file 'LoginScreen.fxml'.";
 
+    }
+
+    private void presentErrorDialog(SuccessCode errorCode) {
+        String errorMessage = this.determineErrorMessage(errorCode);
+        Alert alert = new Alert(AlertType.ERROR);
+        alert.setTitle("An error has occurred.");
+        alert.setHeaderText("The following issue has occurred:");
+        alert.setContentText(errorMessage);
+        alert.showAndWait();
+        return;
+    }
+
+    private String determineErrorMessage(SuccessCode errorCode) {
+        switch (errorCode) {
+            case INVALID_LOGIN_CREDENTIALS:
+                return "The login credentials provided are invalid, please try again or register a new account.";
+            case UNKNOWN_ERROR:
+                return "An Unknown Error has occurred. Please try again.";
+            case USERNAME_ALREADY_EXISTS:
+                return "The username you entered is already in use. Please try again or login.";
+            case USER_NOT_FOUND:
+                return "Account not found with given credentials. Please try again or Create an account.";
+            case INVALID_PASSWORD:
+                return "The password entered is invalid. Please try a different one.";
+            case INVALID_EMAIL:
+                return "The email entered is invalid. Please try a different one.";
+            case INVALID_USERNAME:
+                return "The username entered is invalid. Please try a different one.";
+            default:
+                return "Unknown Error has occurred. Please try again.";
+        }
     }
 
     private void toggleEmailVisibility() {


### PR DESCRIPTION
Removed the System.out method calls to be replaced by a private helper method that creates a dialog if the input is unsuccessful.

-LoginScreen::presentErrorDialog:
this private helper method displays an error dialog based on the success code to provide more precise information to the user on what went wrong when logging in or registering their account.

-LoginScreen::determineErrorMessage:
this private helper method returns an error message based on the success code provided.